### PR TITLE
Unbreak require gulp-s3-deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ var s3Credentials = {
 In your gulp task, deploy your files:
 
 ```javascript
-var s3 = require( "gulp-s3" );
+var s3 = require( "gulp-s3-deploy" );
 gulp.src( './public/**' )
     .pipe( s3( s3Credentials ) );
 ```


### PR DESCRIPTION
This breaks my Gulp file:
```
var s3 = require( "gulp-s3" );
```
Using version 4.0.0-alpha.2
This fixed it:
```
var s3 = require( "gulp-s3-deploy" );
```